### PR TITLE
Handle Empty Result Sets

### DIFF
--- a/lib/opentsdb-consumer/result.rb
+++ b/lib/opentsdb-consumer/result.rb
@@ -25,5 +25,9 @@ module OpenTSDBConsumer
       datapoint = datapoints.max_by { |timestamp, _| timestamp }
       datapoint.last if datapoint
     end
+
+    def empty?
+      datapoints.nil? || datapoints.empty?
+    end
   end
 end

--- a/lib/opentsdb-consumer/result.rb
+++ b/lib/opentsdb-consumer/result.rb
@@ -11,7 +11,14 @@ module OpenTSDBConsumer
 
     def self.build(response)
       results = response.map { |h| new(h) }
-      results.length > 1 ? results : results.first
+      case results.length
+      when 0
+        new('dps' => [])
+      when 1
+        results.first
+      else
+        results
+      end
     end
 
     def latest_value

--- a/spec/opentsdb-consumer/result_spec.rb
+++ b/spec/opentsdb-consumer/result_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe OpenTSDBConsumer::Result do
       expect(results.first).to be_a OpenTSDBConsumer::Result
       expect(results.last).to be_a OpenTSDBConsumer::Result
     end
+
+    it 'returns an empty result object when there is no data' do
+      response = []
+      result = described_class.build(response)
+      expect(result).to be_a OpenTSDBConsumer::Result
+      expect(result.datapoints).to be_an Array
+      expect(result.datapoints).to be_empty
+    end
   end
 
   describe '#latest_value' do

--- a/spec/opentsdb-consumer/result_spec.rb
+++ b/spec/opentsdb-consumer/result_spec.rb
@@ -50,4 +50,21 @@ RSpec.describe OpenTSDBConsumer::Result do
       expect(result.latest_value).to be_nil
     end
   end
+
+  describe '#empty?' do
+    it 'returns false when there is data' do
+      result = described_class.new 'dps' => [{}]
+      expect(result).to_not be_empty
+    end
+
+    it 'returns true when there is no data' do
+      result = described_class.new 'dps' => []
+      expect(result).to be_empty
+    end
+
+    it 'returns true when the datapoints are nil' do
+      result = described_class.new 'dps' => nil
+      expect(result).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
When OpenTSDB returned no data for the query the client returned
a nil value instead of a propper result object. It now returns a
Result object with an empty datapoints array.
