### PR TITLE
Don't build for now unsupported ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 ---
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
 notifications:
   email: false


### PR DESCRIPTION
Drops ruby 2.0 and adds ruby 2.4